### PR TITLE
Update to rules_nodejs 0.32.0

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "e04a82a72146bfbca2d0575947daa60fda1878c8d3a3afe868a8ec39a6b968bb",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.31.1/rules_nodejs-0.31.1.tar.gz"],
+        sha256 = "06cb04f4f745e37d542ec6883a2896029715a591c0e44c5d250a268d3752f865",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.32.0/rules_nodejs-0.32.0.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -10,7 +10,7 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "@build_bazel_rules_sass_deps//node_modules/sass:sass.js",
+    entry_point = "@build_bazel_rules_sass_deps//:node_modules/sass/sass.js",
     install_source_map_support = False,
     data = [
         "@build_bazel_rules_sass_deps//sass",

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -21,7 +21,8 @@ def sass_repositories():
     """
 
     # 0.31.1: entry_point attribute of rules_nodejs is now a label
-    check_rules_nodejs_version("0.31.1")
+    # 0.32.0: @npm//node_modules/foobar:foobar.js labels changed to @npm//:node_modules/foobar/foobar.js with fix for bazelbuild/rules_nodejs#802.
+    check_rules_nodejs_version("0.32.0")
 
     yarn_install(
         name = "build_bazel_rules_sass_deps",


### PR DESCRIPTION
@npm//node_modules/foobar:foobar.js labels changed to @npm//:node_modules/foobar/foobar.js with fix for bazelbuild/rules_nodejs#802